### PR TITLE
feat: path added for show method in single object

### DIFF
--- a/src/spectramap/spectramap.py
+++ b/src/spectramap/spectramap.py
@@ -580,12 +580,17 @@ class single_object:
         self.data = result
         print('Done')
 
-    def show(self, tittle= 'single', method=True):
+    def show(self, tittle= 'single', method=True, path=None, show=True):
         plt.figure()
         plt.plot(self.wavenumber, self.data)
         plt.xlabel('Wavenumber (cm-1)')
         plt.ylabel('Intensity (a.u.)')
         plt.title(self.name)
+        if show:
+            plt.show()
+        if path is not None:
+            plt.savefig(path)
+
 
     def get_intensity(self, wavenumber):
         """


### PR DESCRIPTION
This PR updates `single_object.show` to:

-   Display the plot using `plt.show()` (enabled by default).
-   Save the plot to a file path specified via the `path` parameter.